### PR TITLE
Fix issue when different implementation of WebDriver was used in code.

### DIFF
--- a/graphene/impl/src/main/java/org/jboss/arquillian/graphene/angular/AngularJSDroneExtension.java
+++ b/graphene/impl/src/main/java/org/jboss/arquillian/graphene/angular/AngularJSDroneExtension.java
@@ -45,7 +45,7 @@ public class AngularJSDroneExtension implements LoadableExtension {
 
         @Override
         public boolean canEnhance(InstanceOrCallableInstance instance, Class<?> droneType, Class<? extends Annotation> qualifier) {
-            return WebDriver.class.isAssignableFrom(droneType);
+            return droneType.isAssignableFrom(EventFiringWebDriver.class);
         }
 
         @Override


### PR DESCRIPTION
The way the drone is enhanced by this extension is just simply creating
a delegate, but when user uses different implementation of WebDriver in
code, the drone won't be able to be injected, because of incompatible
types.
